### PR TITLE
Add support for custom TLS certs

### DIFF
--- a/httpreplay/cmd/httpr/README.md
+++ b/httpreplay/cmd/httpr/README.md
@@ -37,7 +37,7 @@ releases page](https://github.com/googleapis/google-cloud-go/releases).
    `http://localhost:8181/authority.cer`. (If you changed the control port, use
    it in place of 8181.)  Consult your language to determine
    how to install the certificate. Note that the certificate is different for each run
-   of `httpr`.
+   of `httpr`. A custom certficate can also be provided with `-cert` and `-key`.
 1. Arrange for your test program to use `httpr` as a proxy. This may be as
    simple as setting the `HTTPS_PROXY` environment variable.
 1. Run your test program, using whatever authentication for your Google API
@@ -51,7 +51,8 @@ releases page](https://github.com/googleapis/google-cloud-go/releases).
    ```
    httpr -replay myclient.replay
    ```
-1. Install the CA certificate as described above.
+1. Install the CA certificate as described above or provide a custom `-cert`
+   and `-key`.
 1. Have your test program treat `httpr` as a proxy, as described above.
 1. Run your test program. Your Google API clients should use no authentication.
 

--- a/httpreplay/cmd/httpr/httpr.go
+++ b/httpreplay/cmd/httpr/httpr.go
@@ -57,9 +57,9 @@ func main() {
 	var pr *proxy.Proxy
 	var err error
 	if *record != "" {
-		pr, err = proxy.ForRecording(*record, *port, *cert, *priv)
+		pr, err = proxy.ForRecording(*record, *port, *cert, *key)
 	} else {
-		pr, err = proxy.ForReplaying(*replay, *port, *cert, *priv)
+		pr, err = proxy.ForReplaying(*replay, *port, *cert, *key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/httpreplay/cmd/httpr/httpr.go
+++ b/httpreplay/cmd/httpr/httpr.go
@@ -39,6 +39,8 @@ var (
 	controlPort  = flag.Int("control-port", 8181, "port for controlling the proxy")
 	record       = flag.String("record", "", "record traffic and save to filename")
 	replay       = flag.String("replay", "", "read filename and replay traffic")
+	cert         = flag.String("cert", "", "The server certificate file path")
+	key          = flag.String("key", "", "The private key file path")
 	debugHeaders = flag.Bool("debug-headers", false, "log header mismatches")
 )
 
@@ -55,9 +57,9 @@ func main() {
 	var pr *proxy.Proxy
 	var err error
 	if *record != "" {
-		pr, err = proxy.ForRecording(*record, *port)
+		pr, err = proxy.ForRecording(*record, *port, *cert, *priv)
 	} else {
-		pr, err = proxy.ForReplaying(*replay, *port)
+		pr, err = proxy.ForReplaying(*replay, *port, *cert, *priv)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/httpreplay/httpreplay.go
+++ b/httpreplay/httpreplay.go
@@ -96,9 +96,9 @@ func RecorderPort(port int) recorderOption {
 }
 
 // NewRecorderWithOpts creates a recorder that writes to filename.
-// The Recorder MITM proxy shall be configured with a custom certficate by
-// providing paths to certs and key, in case where the custom certificate is
-// not provided, the proxy will be created with an auto-generated certificate
+// The default Recorder MITM proxy can be customised with one or more
+// recorderOption.
+//
 // You must call Close on the Recorder to ensure that all data is written.
 func NewRecorderWithOpts(filename string, opts ...recorderOption) (*Recorder, error) {
 	r := &Recorder{port: 0, initial: nil, cert: "", key: ""}
@@ -214,9 +214,8 @@ func ReplayerPort(port int) replayerOption {
 	}
 }
 
-// NewReplayerWithOpts creates a replayer that reads from filename.
-//
-// You must call Close on the Recorder to ensure that all data is written.
+// NewReplayerWithOpts creates a replayer that reads from filename. The default
+// Replayer MITM proxy can be customised with one or more replayerOption.
 func NewReplayerWithOpts(filename string, opts ...replayerOption) (*Replayer, error) {
 	r := &Replayer{port: 0, cert: "", key: ""}
 	for _, opt := range opts {
@@ -230,10 +229,7 @@ func NewReplayerWithOpts(filename string, opts ...replayerOption) (*Replayer, er
 	return r, nil
 }
 
-// NewReplayer creates a replayer that reads from filename. The Replayer MITM
-// proxy shall be configured with a custom certificate by providing paths to
-// cert and key, in case where the custom certificate is not provided, the
-// proxy will be created with an auto-generated certificate.
+// NewReplayer creates a replayer that reads from filename.
 func NewReplayer(filename string) (*Replayer, error) {
 	p, err := proxy.ForReplaying(filename, 0, "", "")
 	if err != nil {

--- a/httpreplay/internal/proxy/record.go
+++ b/httpreplay/internal/proxy/record.go
@@ -20,6 +20,7 @@ package proxy
 // See github.com/google/martian/cmd/proxy/main.go for the origin of much of this.
 
 import (
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -109,7 +110,7 @@ var (
 func newProxy(filename, c, k string) (*Proxy, error) {
 	configOnce.Do(func() {
 		var x509c *x509.Certificate
-		var priv interface{}
+		var priv crypto.PrivateKey
 		var err error
 		// Set up a man-in-the-middle configuration with a CA certificate so the proxy can
 		// participate in TLS.
@@ -143,7 +144,7 @@ func newProxy(filename, c, k string) (*Proxy, error) {
 	}, nil
 }
 
-func customCert(cert, key string) (*x509.Certificate, interface{}, error) {
+func customCert(cert, key string) (*x509.Certificate, crypto.PrivateKey, error) {
 	tlsc, err := tls.LoadX509KeyPair(cert, key)
 	if err != nil {
 		return nil, nil, err
@@ -157,7 +158,7 @@ func customCert(cert, key string) (*x509.Certificate, interface{}, error) {
 	return x509c, priv, nil
 }
 
-func autoGenCert() (*x509.Certificate, interface{}, error) {
+func autoGenCert() (*x509.Certificate, crypto.PrivateKey, error) {
 	return mitm.NewAuthority("github.com/google/go-replayers/httpreplay", "HTTPReplay Authority", 100*time.Hour)
 }
 

--- a/httpreplay/internal/proxy/replay.go
+++ b/httpreplay/internal/proxy/replay.go
@@ -29,8 +29,8 @@ import (
 )
 
 // ForReplaying returns a Proxy configured to replay.
-func ForReplaying(filename string, port int) (*Proxy, error) {
-	p, err := newProxy(filename)
+func ForReplaying(filename string, port int, cert, key string) (*Proxy, error) {
+	p, err := newProxy(filename, cert, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`-cert` and `-key` can be used to specify the file paths to the custom
certificate and key on the disk. The custom certificate is also supported
when `go-replayers/httpreplay` is used as a library in go code.