### PR TITLE
Add RemoveResponseHeaders

### DIFF
--- a/httpreplay/httpreplay.go
+++ b/httpreplay/httpreplay.go
@@ -135,6 +135,14 @@ func (r *Recorder) RemoveRequestHeaders(patterns ...string) {
 	r.proxy.RemoveRequestHeaders(patterns)
 }
 
+// RemoveResponseHeaders will remove response headers matching patterns from the log,
+// and skip matching them during replay.
+//
+// Pattern is taken literally except for *, which matches any sequence of characters.
+func (r *Recorder) RemoveResponseHeaders(patterns ...string) {
+	r.proxy.RemoveResponseHeaders(patterns)
+}
+
 // ClearHeaders will replace the value of request and response headers that match
 // any of the patterns with CLEARED, on both recording and replay.
 // Use ClearHeaders when the header information is secret or may change from run to

--- a/httpreplay/internal/proxy/converter.go
+++ b/httpreplay/internal/proxy/converter.go
@@ -61,6 +61,10 @@ func (c *Converter) registerRemoveRequestHeaders(pat string) {
 	c.RemoveRequestHeaders = append(c.RemoveRequestHeaders, pattern(pat))
 }
 
+func (c *Converter) registerRemoveResponseHeaders(pat string) {
+	c.RemoveResponseHeaders = append(c.RemoveResponseHeaders, pattern(pat))
+}
+
 func (c *Converter) registerClearHeaders(pat string) {
 	c.ClearHeaders = append(c.ClearHeaders, pattern(pat))
 }

--- a/httpreplay/internal/proxy/record.go
+++ b/httpreplay/internal/proxy/record.go
@@ -205,6 +205,18 @@ func (p *Proxy) RemoveRequestHeaders(patterns []string) {
 	}
 }
 
+// RemoveResponseHeaders will remove response headers matching patterns from the log,
+// and skip matching them. Pattern is taken literally except for *, which matches any
+// sequence of characters.
+//
+// This only needs to be called during recording; the patterns will be saved to the
+// log for replay.
+func (p *Proxy) RemoveResponseHeaders(patterns []string) {
+	for _, pat := range patterns {
+		p.logger.log.Converter.registerRemoveResponseHeaders(pat)
+	}
+}
+
 // ClearHeaders will replace matching headers with CLEARED.
 //
 // This only needs to be called during recording; the patterns will be saved to the


### PR DESCRIPTION
Adds `RemoveResponseHeaders` method that allows removal of certain headers from response recording, associated plumbing, and test coverage. Intent is to make it easy to remove useless headers added by proxies and the like.