### PR TITLE
grpcreplay: fix any interface alias type shadowing

### DIFF
--- a/grpcreplay/grpcreplay.go
+++ b/grpcreplay/grpcreplay.go
@@ -719,14 +719,14 @@ func readEntry(r io.Reader) (*entry, error) {
 	}
 	var msg message
 	if pe.Message != nil {
-		any, err := pe.Message.UnmarshalNew()
+		a, err := pe.Message.UnmarshalNew()
 		if err != nil {
 			return nil, err
 		}
 		if pe.IsError {
-			msg.err = status.ErrorProto(any.ProtoReflect().Interface().(*spb.Status))
+			msg.err = status.ErrorProto(a.ProtoReflect().Interface().(*spb.Status))
 		} else {
-			msg.msg = any.ProtoReflect().Interface()
+			msg.msg = a.ProtoReflect().Interface()
 		}
 	} else if pe.IsError {
 		msg.err = io.EOF


### PR DESCRIPTION
grpcreplay: fix `any` interface alias type shadowing.