### PR TITLE
grpcreplay: reject oversized record size in readRecord to prevent OOM

### DIFF
--- a/grpcreplay/binary_format.go
+++ b/grpcreplay/binary_format.go
@@ -17,11 +17,16 @@ package grpcreplay
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 
 	pb "github.com/google/go-replayers/grpcreplay/proto/grpcreplay"
 	"google.golang.org/protobuf/proto"
 )
+
+// maxRecordSize guards against OOM when parsing a crafted replay file.
+// gRPC's default max message size is 4 MiB; 64 MiB is a generous upper bound.
+const maxRecordSize = 64 << 20 // 64 MiB
 
 type binaryWriter struct {
 	w io.Writer
@@ -97,6 +102,9 @@ func (r *binaryReader) readRecord() ([]byte, error) {
 	var size uint32
 	if err := binary.Read(r.r, binary.LittleEndian, &size); err != nil {
 		return nil, err
+	}
+	if size > maxRecordSize {
+		return nil, fmt.Errorf("grpcreplay: record size %d exceeds maximum %d", size, maxRecordSize)
 	}
 	buf := make([]byte, size)
 	if _, err := io.ReadFull(r.r, buf); err != nil {

--- a/grpcreplay/grpcreplay_test.go
+++ b/grpcreplay/grpcreplay_test.go
@@ -17,6 +17,7 @@ package grpcreplay
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"reflect"
@@ -703,4 +704,21 @@ func TestSetInitial(t *testing.T) {
 	if got, want := rep.Initial(), initialState; !bytes.Equal(got, want) {
 		t.Errorf("got initial state %q, want %q", got, want)
 	}
+}
+
+// TestOversizeRecord is a regression test for OOM via unchecked readRecord size.
+// A crafted binary replay file with size > maxRecordSize must be rejected with
+// an error rather than causing a large allocation.
+func TestOversizeRecord(t *testing.T) {
+	var buf bytes.Buffer
+	// Write an oversize size field (maxRecordSize + 1).
+	binary.Write(&buf, binary.LittleEndian, uint32(maxRecordSize+1))
+
+	r := &binaryReader{r: &buf}
+	// readHeader() calls readRecord() internally.
+	_, err := r.readRecord()
+	if err == nil {
+		t.Fatal("readRecord should return an error for size > maxRecordSize")
+	}
+	t.Logf("correctly rejected oversized record: %v", err)
 }


### PR DESCRIPTION
## Summary

`readRecord()` in `grpcreplay/binary_format.go` reads `size` as a raw `uint32`
from the replay file and passes it directly to `make([]byte, size)` with no
bounds check. A crafted 13-byte `.grpc_replay` file can trigger a **4 GB
allocation** in any program that calls `grpcreplay.NewReplayer()` on an
attacker-supplied file.

### Vulnerable code (before this fix)

```go
func (r *binaryReader) readRecord() ([]byte, error) {
    var size uint32
    binary.Read(r.r, binary.LittleEndian, &size)
    buf := make([]byte, size) // no bounds check: up to 4 GB
```

### Trigger file (13 bytes)

| Field | Value |
|---|---|
| Magic | `RPCReplay` (9 bytes) |
| size | `0xffffffff` (4 bytes LE) |

Standalone reproducer output (size capped at 512 MB to avoid crashing the host):

```
[*] Crafted replay file: 13 bytes
[*] Encoded size: 0x20000000 (512 MB)
[*] TotalAlloc before parse: 0 MB
[*] TotalAlloc after parse:  512 MB (delta: +512 MB)
[!] VULNERABLE: 512 MB allocated from a 13-byte replay file.
```

### Fix

Add `maxRecordSize = 64 MiB` constant (gRPC's own default max message size
is 4 MiB; 64 MiB is a generous upper bound) and reject records that exceed
it before allocation.

### Testing

`TestOversizeRecord` in `grpcreplay_test.go` verifies that `readRecord()`
returns an error for an oversized size field without causing a large allocation.